### PR TITLE
modified load_procedures to use sorted file list, and make_proc_doc as same

### DIFF
--- a/lib/flor/core.rb
+++ b/lib/flor/core.rb
@@ -74,7 +74,7 @@ module Flor
         File.join(File.dirname(__FILE__), dir, '*.rb')
       end
 
-    Dir[dirpath].each { |path| require(path) }
+    Dir[dirpath].sort.each { |path| require(path) }
   end
 end
 

--- a/mak/doc.rb
+++ b/mak/doc.rb
@@ -65,7 +65,7 @@ def make_procedures_doc
 
   procs =
     (
-      Dir["lib/flor/pcore/*.rb"] + Dir["lib/flor/punit/*.rb"]
+      Dir["lib/flor/pcore/*.rb"].sort + Dir["lib/flor/punit/*.rb"].sort
     ).collect { |path| make_proc_doc(path) }.compact
   pp procs
 


### PR DESCRIPTION
I want to use `flor' on my Ubuntu environment.
But,  I can't use it because of Exception as follow:

<pre>
micky@micky-worku:~/flor/quickstart$ bundle exec ruby quickstart.rb
/home/micky/flor/lib/flor/pcore/match.rb:2:in `<top (required)>': uninitialized constant Flor::Pro::Case (NameError)
        from /home/micky/flor/lib/flor/core.rb:77:in `require'
        from /home/micky/flor/lib/flor/core.rb:77:in `block in load_procedures'
        from /home/micky/flor/lib/flor/core.rb:77:in `each'
        from /home/micky/flor/lib/flor/core.rb:77:in `load_procedures'
        from /home/micky/flor/lib/flor.rb:38:in `<top (required)>'
        from /home/micky/flor/lib/flor/unit.rb:7:in `require'
        from /home/micky/flor/lib/flor/unit.rb:7:in `<top (required)>'
        from quickstart.rb:4:in `require'
        from quickstart.rb:4:in `<main>'
</pre>

This patch solves the problem.