### PR TITLE
Fix load_messages, and add message model

### DIFF
--- a/lib/flor/unit/models.rb
+++ b/lib/flor/unit/models.rb
@@ -47,7 +47,7 @@ module Flor
     end
   end
 
-  MODELS = [ :executions, :timers, :traces, :traps, :pointers ]
+  MODELS = [ :executions, :timers, :traces, :traps, :pointers, :messages ]
 
   dir = File.dirname(__FILE__)
   MODELS.each { |m| require File.join(dir, 'models', "#{m.to_s[0..-2]}.rb") }

--- a/lib/flor/unit/models/message.rb
+++ b/lib/flor/unit/models/message.rb
@@ -1,0 +1,7 @@
+
+module Flor
+
+  class Message < FlorModel
+  end
+end
+

--- a/lib/flor/unit/storage.rb
+++ b/lib/flor/unit/storage.rb
@@ -191,14 +191,10 @@ module Flor
 
       synchronize do
 
-        _exids_being_processed =
-          @db[:flor_messages]
-            .select(:exid)
-            .exclude(status: %w[ created consumed ])
         _exids =
           @db[:flor_messages]
             .select(:exid)
-            .exclude(exid: _exids_being_processed)
+            .exclude(status: %w[ reserved consumed ])
             .limit(exe_count)
         @db[:flor_messages]
           .where(exid: _exids, status: 'created')

--- a/lib/flor/unit/storage.rb
+++ b/lib/flor/unit/storage.rb
@@ -191,9 +191,14 @@ module Flor
 
       synchronize do
 
+        _exids_being_processed =
+          @db[:flor_messages]
+            .select(:exid)
+            .exclude(status: %w[ created consumed ])
         _exids =
           @db[:flor_messages]
             .select(:exid)
+            .exclude(exid: _exids_being_processed)
             .exclude(status: %w[ reserved consumed ])
             .limit(exe_count)
         @db[:flor_messages]


### PR DESCRIPTION
I want to get the last message of a launched execution from flack.
But, I can't get it because flor removes consumed messages.
So, I'll use storage archive mode: configured sto_archive: true. but flor loops after second launch.
This patch resolves the problem, and adds message model to access messages.
