### PR TITLE
add missing methods to DummySequelAdaptor

### DIFF
--- a/lib/flor/unit/models.rb
+++ b/lib/flor/unit/models.rb
@@ -6,6 +6,7 @@ module Flor
     class Db
       def supports_schema_parsing?; false; end
       def transaction(opts={}); yield; end
+      
     end
 
     def initialize(opts)
@@ -15,6 +16,11 @@ module Flor
     end
 
     def fetch_rows(sql); yield([]); end
+    #DJV 
+    # add mising methods from dummy adaptor
+    def typecast_value_boolean(opts={});true;end
+    def test_connection();true;end
+    #DJV
 
     DB = Sequel.connect(:adapter => Flor::DummySequelAdapter)
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,7 +12,7 @@ require 'jruby/synchronized' if RUBY_PLATFORM.match(/java/)
 
 require 'flor'
 require 'flor/unit'
-
+require 'fileutils'
 
 F = Flor
   # quicker access to Flor.to_s and co


### PR DESCRIPTION
Under linux with sqlite3 (1.3.11) in Gemfile.lock, I was getting the error 
`Failure/Error: DB = Sequel.connect(:adapter => Flor::DummySequelAdapter)

NoMethodError:
  undefined method `typecast_value_boolean' for #<Flor::DummySequelAdapter: "SELECT *">
`
but creating the first method fixed it. Then I got the second error about test_connection, so I fixed it too. Please have a look and see if you agree.
