### PR TITLE
Ensure primary keys are auto incremented

### DIFF
--- a/lib/flor/migrations/0001_tables.rb
+++ b/lib/flor/migrations/0001_tables.rb
@@ -5,7 +5,7 @@ Sequel.migration do
 
     create_table :flor_messages do
 
-      primary_key :id, type: :Integer
+      primary_key :id
       String :domain, null: false
       String :exid, null: false
       String :point, null: false # 'execute', 'task', 'receive', 'schedule', ...
@@ -19,7 +19,7 @@ Sequel.migration do
 
     create_table :flor_executions do
 
-      primary_key :id, type: :Integer
+      primary_key :id
       String :domain, null: false
       String :exid, null: false
       File :content # JSON
@@ -32,7 +32,7 @@ Sequel.migration do
 
     create_table :flor_timers do
 
-      primary_key :id, type: :Integer
+      primary_key :id
       String :domain, null: false
       String :exid, null: false
       String :nid, null: false
@@ -51,7 +51,7 @@ Sequel.migration do
 
     create_table :flor_traps do
 
-      primary_key :id, type: :Integer
+      primary_key :id
       String :domain, null: false
       String :exid, null: false
       String :onid, null: false
@@ -76,7 +76,7 @@ Sequel.migration do
 
     create_table :flor_pointers do
 
-      primary_key :id, type: :Integer
+      primary_key :id
       String :domain, null: false
       String :exid, null: false
       String :nid, null: false
@@ -97,7 +97,7 @@ Sequel.migration do
 
     create_table :flor_traces do
 
-      primary_key :id, type: :Integer
+      primary_key :id
       String :domain, null: false
       String :exid, null: false
       String :nid, null: true


### PR DESCRIPTION
Only tested with postgresql 9.5

By specifying the primary_key's `type` the database does not auto increment new records id's leading to a not null constraint violation.

Ideally I'd make a new migration instead of modifying a previous one, but unsure how to start auto increment with an existing table.

This should be backwards compatible though since Integer is default anyway