### PR TITLE
Gemspec: Drop EOL'd property rubyforge_project

### DIFF
--- a/flor.gemspec
+++ b/flor.gemspec
@@ -11,7 +11,6 @@ Gem::Specification.new do |s|
   s.authors = [ 'John Mettraux' ]
   s.email = [ 'jmettraux+flor@gmail.com' ]
   s.homepage = 'http://github.com/floraison'
-  #s.rubyforge_project = 'flor'
   s.license = 'MIT'
   s.summary = 'A Ruby workflow engine'
 


### PR DESCRIPTION
The RubyGems property rubyforge_project is removed without a replacement.