### PR TITLE
WIP: Nested traps are not triggered by external signal messages

### DIFF
--- a/spec/unit/scheduler_spec.rb
+++ b/spec/unit/scheduler_spec.rb
@@ -483,6 +483,52 @@ describe 'Flor unit' do
           s0:
         ])
       end
+
+      it 'triggers a blocking trap' do
+
+        r = @unit.launch(
+          %q{
+            trace 'a'
+            trace 'b'
+            trap signal: 'S0'
+            trace 'c'
+          })
+        wait_until { @unit.traps.count == 1 }
+
+        @unit.signal('S0', exid: r)
+
+        wait_until { @unit.traces.count == 3 }
+
+        expect(
+          @unit.traces.collect(&:text)
+        ).to eq(%w[
+          a b c
+        ])
+      end
+
+      it 'triggers a nested blocking trap' do
+
+        r = @unit.launch(
+          %q{
+            trace 'a'
+            sequence
+              trace 'b'
+              trap signal: 'S0'
+              trace 'c'
+          })
+
+        wait_until { @unit.traps.count == 1 }
+
+        @unit.signal('S0', exid: r)
+
+        wait_until { @unit.traces.count == 3 }
+
+        expect(
+          @unit.traces.collect(&:text)
+        ).to eq(%w[
+          a b c
+        ])
+      end
     end
 
     context 'sch_msg_max_res_time' do
@@ -1025,4 +1071,3 @@ describe 'Flor unit' do
     end
   end
 end
-


### PR DESCRIPTION
Traps with `range = 'subnid'` and `bnid != '0'` cannot match any external signal messages (`@unit.signal(...)`)


The hooker returns false for a match here (L165):
https://github.com/floraison/flor/blob/a277c76520efda2088c651a7995c8df5c7513b9d/lib/flor/unit/hooker.rb#L161-L166

`@unit.schedule` emits a message without a `nid` and bnid is not 0.

Is this by design or is this a bug? I'm keen to add a fix to this PR if it is a bug