### PR TITLE
Reduce allocations

### DIFF
--- a/lib/flor/parser.rb
+++ b/lib/flor/parser.rb
@@ -1,4 +1,4 @@
-
+# frozen_string_literal: true
 module Flor
 
   def self.parse(input, fname=nil, opts={})
@@ -727,4 +727,3 @@ fail "don't know how to invert #{operation.inspect}" # FIXME
     sio.string
   end
 end
-

--- a/lib/flor/unit/hooker.rb
+++ b/lib/flor/unit/hooker.rb
@@ -1,4 +1,4 @@
-
+# frozen_string_literal: true
 module Flor
 
   class Hooker
@@ -186,4 +186,3 @@ module Flor
     end
   end
 end
-

--- a/lib/flor/unit/hooker.rb
+++ b/lib/flor/unit/hooker.rb
@@ -87,10 +87,7 @@ module Flor
 
     protected
 
-    def o(opts, *keys)
-
-      array = false
-      array = keys.pop if keys.last == []
+    def o(opts, *keys, array: false)
 
       r = nil
       keys.each { |k| break r = opts[k] if opts.has_key?(k) }
@@ -118,7 +115,7 @@ module Flor
         return false if hook.within_itself?(executor, message)
       end
 
-      ps = o(opts, :point, :p, [])
+      ps = o(opts, :point, :p, array: true)
       return false if ps && ! ps.include?(message['point'])
 
       if nid = o(opts, :nid)
@@ -133,19 +130,19 @@ module Flor
 
       dm = Flor.domain(message['exid'])
 
-      if dm && ds = o(opts, :domain, :d, [])
+      if dm && ds = o(opts, :domain, :d, array: true)
         return false \
           unless ds.find { |d| d.is_a?(Regexp) ? (!! d.match(dm)) : (d == dm) }
       end
 
-      if dm && sds = o(opts, :subdomain, :sd, [])
+      if dm && sds = o(opts, :subdomain, :sd, array: true)
         return false \
           unless sds.find do |sd|
             dm[0, sd.length] == sd
           end
       end
 
-      if ts = o(opts, :tag, :t, [])
+      if ts = o(opts, :tag, :t, array: true)
         return false unless %w[ entered left ].include?(message['point'])
         return false unless includes?(ts, message['tags'])
       end
@@ -172,12 +169,12 @@ module Flor
         end
       end
 
-      if hps = o(opts, :heap, :hp, [])
+      if hps = o(opts, :heap, :hp, array: true)
         return false unless node ||= executor.node(message['nid'])
         return false unless includes?(hps, node['heap'])
       end
 
-      if hts = o(opts, :heat, :ht, [])
+      if hts = o(opts, :heat, :ht, array: true)
         return false unless node ||= executor.node(message['nid'])
         return false unless includes?(hts, node['heat0'])
       end


### PR DESCRIPTION
A large flor process was allocating a lot of memory on launch:

```
 186480928  TOTAL (bytes)
 101159983  flor-90a7f88008a3
  31303989  raabro-1.3.3
  31106951  lib
   9382470  sequel-5.36.0
   7451852  activesupport-6.0.3.2
   4446632  activerecord-6.0.3.2
   4026885  bootsnap-1.4.8
   3471372  activemodel-6.0.3.2
   1424922  railties-6.0.3.2
   1324797  dense-1.1.6
```

The same launch with this PR:
```
 143217882  TOTAL (bytes)
  57515019  flor-8b2396ce8d1c
  31306685  lib
  31303344  raabro-1.3.3
   9333265  sequel-5.36.0
   6816050  activesupport-6.0.3.2
   3168102  activerecord-6.0.3.2
   1437332  railties-6.0.3.2
   1324749  dense-1.1.6
    679127  bootsnap-1.4.8
    135840  activemodel-6.0.3.2
```

I've since split this process into multiple more manageable processes.


These changes are just the low hanging fruit and more work could be done if necessary. Here's top allocations by location for the same launch (using this PR):
```
  30130170  /ruby/2.7.1/lib/ruby/2.7.0/json/common.rb:156
  10779200  /ruby/2.7.1/lib/ruby/gems/2.7.0/bundler/gems/flor-8b2396ce8d1c/lib/flor/unit/hooker.rb:92
  10353652  /ruby/2.7.1/lib/ruby/gems/2.7.0/gems/raabro-1.3.3/lib/raabro.rb:252
   4316112  /ruby/2.7.1/lib/ruby/gems/2.7.0/gems/raabro-1.3.3/lib/raabro.rb:273
   4236041  /ruby/2.7.1/lib/ruby/gems/2.7.0/bundler/gems/flor-8b2396ce8d1c/lib/flor/unit/storage.rb:860
   3725546  /ruby/2.7.1/lib/ruby/gems/2.7.0/gems/sequel-5.36.0/lib/sequel/adapters/postgres.rb:796
   3225084  /ruby/2.7.1/lib/ruby/gems/2.7.0/bundler/gems/flor-8b2396ce8d1c/lib/flor/parser.rb:267
   3147048  /ruby/2.7.1/lib/ruby/gems/2.7.0/gems/raabro-1.3.3/lib/raabro.rb:21
   2977296  /ruby/2.7.1/lib/ruby/gems/2.7.0/gems/raabro-1.3.3/lib/raabro.rb:56
   2831904  /ruby/2.7.1/lib/ruby/gems/2.7.0/gems/raabro-1.3.3/lib/raabro.rb:234
   2516960  /ruby/2.7.1/lib/ruby/gems/2.7.0/bundler/gems/flor-8b2396ce8d1c/lib/flor/core/procedure.rb:33
   2516720  /ruby/2.7.1/lib/ruby/gems/2.7.0/bundler/gems/flor-8b2396ce8d1c/lib/flor/core/procedure.rb:26
   2249920  /ruby/2.7.1/lib/ruby/gems/2.7.0/gems/sequel-5.36.0/lib/sequel/adapters/postgres.rb:793
   2214232  /ruby/2.7.1/lib/ruby/gems/2.7.0/bundler/gems/flor-8b2396ce8d1c/lib/flor/unit/hooker.rb:85
   2196280  /ruby/2.7.1/lib/ruby/gems/2.7.0/bundler/gems/flor-8b2396ce8d1c/lib/flor/core/executor.rb:133
   2179663  /ruby/2.7.1/lib/ruby/gems/2.7.0/gems/activesupport-6.0.3.2/lib/active_support/backtrace_cleaner.rb:96
   1995672  /ruby/2.7.1/lib/ruby/gems/2.7.0/bundler/gems/flor-8b2396ce8d1c/lib/flor/unit/loader.rb:235
   1952037  /ruby/2.7.1/lib/ruby/gems/2.7.0/gems/activerecord-6.0.3.2/lib/active_record/log_subscriber.rb:105
   1908040  /ruby/2.7.1/lib/ruby/gems/2.7.0/bundler/gems/flor-8b2396ce8d1c/lib/flor/id.rb:32
   1584000  /ruby/2.7.1/lib/ruby/gems/2.7.0/bundler/gems/flor-8b2396ce8d1c/lib/flor/unit/loader.rb:230
   1502688  /ruby/2.7.1/lib/ruby/gems/2.7.0/gems/raabro-1.3.3/lib/raabro.rb:287
   1385267  /ruby/2.7.1/lib/ruby/gems/2.7.0/bundler/gems/flor-8b2396ce8d1c/lib/flor/unit/loader.rb:233
   1246008  /ruby/2.7.1/lib/ruby/gems/2.7.0/bundler/gems/flor-8b2396ce8d1c/lib/flor/unit/loader.rb:243
   1239463  /ruby/2.7.1/lib/ruby/gems/2.7.0/gems/sequel-5.36.0/lib/sequel/adapters/postgres.rb:537
   1165904  /ruby/2.7.1/lib/ruby/gems/2.7.0/bundler/gems/flor-8b2396ce8d1c/lib/flor/unit/loader.rb:220
   1153425  /ruby/2.7.1/lib/ruby/gems/2.7.0/gems/activesupport-6.0.3.2/lib/active_support/core_ext/marshal.rb:6
   1107840  /ruby/2.7.1/lib/ruby/gems/2.7.0/bundler/gems/flor-8b2396ce8d1c/lib/flor/core/node.rb:431
   1102480  /ruby/2.7.1/lib/ruby/gems/2.7.0/bundler/gems/flor-8b2396ce8d1c/lib/flor/id.rb:69
   1068277  /ruby/2.7.1/lib/ruby/gems/2.7.0/gems/railties-6.0.3.2/lib/rails/backtrace_cleaner.rb:16
    926697  /ruby/2.7.1/lib/ruby/2.7.0/json/common.rb:224
    878760  /ruby/2.7.1/lib/ruby/gems/2.7.0/gems/raabro-1.3.3/lib/raabro.rb:297
    871008  /ruby/2.7.1/lib/ruby/gems/2.7.0/gems/activesupport-6.0.3.2/lib/active_support/core_ext/object/json.rb:153
    856829  /ruby/2.7.1/lib/ruby/gems/2.7.0/bundler/gems/flor-8b2396ce8d1c/lib/flor/unit/loader.rb:231
    838704  /ruby/2.7.1/lib/ruby/gems/2.7.0/gems/raabro-1.3.3/lib/raabro.rb:73
    811216  /ruby/2.7.1/lib/ruby/gems/2.7.0/bundler/gems/flor-8b2396ce8d1c/lib/flor/unit/loader.rb:234
    788640  /ruby/2.7.1/lib/ruby/gems/2.7.0/bundler/gems/flor-8b2396ce8d1c/lib/flor/flor.rb:374
    788640  /ruby/2.7.1/lib/ruby/gems/2.7.0/bundler/gems/flor-8b2396ce8d1c/lib/flor/unit/loader.rb:89
    760800  /ruby/2.7.1/lib/ruby/gems/2.7.0/gems/raabro-1.3.3/lib/raabro.rb:457
    691968  /ruby/2.7.1/lib/ruby/gems/2.7.0/bundler/gems/flor-8b2396ce8d1c/lib/flor/unit/loader.rb:87
    661576  /ruby/2.7.1/lib/ruby/gems/2.7.0/bundler/gems/flor-8b2396ce8d1c/lib/flor/core/procedure.rb:602
    592760  /ruby/2.7.1/lib/ruby/gems/2.7.0/gems/raabro-1.3.3/lib/raabro.rb:26
    563640  /ruby/2.7.1/lib/ruby/gems/2.7.0/bundler/gems/flor-8b2396ce8d1c/lib/flor/unit/models/trap.rb:38
    557088  /ruby/2.7.1/lib/ruby/gems/2.7.0/gems/raabro-1.3.3/lib/raabro.rb:332
    525840  /ruby/2.7.1/lib/ruby/gems/2.7.0/bundler/gems/flor-8b2396ce8d1c/lib/flor/flor.rb:285
    519705  /ruby/2.7.1/lib/ruby/gems/2.7.0/gems/raabro-1.3.3/lib/raabro.rb:22
    500280  /ruby/2.7.1/lib/ruby/gems/2.7.0/gems/raabro-1.3.3/lib/raabro.rb:571
    458848  /ruby/2.7.1/lib/ruby/gems/2.7.0/gems/bootsnap-1.4.8/lib/bootsnap/load_path_cache/cache.rb:119
    430320  /ruby/2.7.1/lib/ruby/gems/2.7.0/bundler/gems/flor-8b2396ce8d1c/lib/flor/unit/loader.rb:221
    430320  /ruby/2.7.1/lib/ruby/gems/2.7.0/bundler/gems/flor-8b2396ce8d1c/lib/flor/unit/loader.rb:229
    430320  /ruby/2.7.1/lib/ruby/gems/2.7.0/bundler/gems/flor-8b2396ce8d1c/lib/flor/unit/loader.rb:232
```

